### PR TITLE
feat(): support private ob

### DIFF
--- a/charts/mo-ob-private/.helmignore
+++ b/charts/mo-ob-private/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mo-ob-private/Chart.yaml
+++ b/charts/mo-ob-private/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: mo-ob-private
+description: mo-ob-private's Helm chart for Kubernetes
+type: application
+version: 1.0.0-alpha
+appVersion: 0.9.0
+dependencies:
+- condition: mo-ob-opensource.enabled
+  name: mo-ob-opensource
+  repository: https://matrixone-cloud.github.io/observability
+  version: 1.0.0-alpha.16
+- condition: mo-ruler-stack.enabled
+  name: mo-ruler-stack
+  repository: https://matrixone-cloud.github.io/observability
+  version: 1.0.0-alpha.13
+

--- a/charts/mo-ob-private/README.md
+++ b/charts/mo-ob-private/README.md
@@ -1,0 +1,66 @@
+## MO OB Private Deploy Chart
+
+original issue: https://github.com/matrixorigin/MO-Cloud/issues/2266
+
+---
+
+
+## Quick Start
+
+To Set up a private ob:
+
+1. clone this repo
+
+2. set env:
+   
+    ```
+    OBNS=mo-ob
+    S3_ENDPOINT=s3-endpoint
+    S3_ACCESS_KEY=s3-access-key
+    S3_SECRET_KEY=s3-secret-key
+    S3_BUCKET=bucket_name
+    STORAGE_CLASS=storage_class
+    PROM_STORAGE_SIZE=40Gi
+    GRAFANA_USER=admin
+    GRAFANA_PWD=matrixorigin2021
+    ```
+
+3. run
+
+```
+	helm install -n ${OBNS} \
+		--set mo-ob-opensource.loki.loki.storage.bucketNames.chunks=${S3_BUCKET} \
+		--set mo-ob-opensource.loki.loki.storage.s3.endpoint=${S3_ENDPOINT} \
+		--set mo-ob-opensource.loki.loki.storage.s3.accessKeyId=${S3_ACCESS_KEY} \
+		--set mo-ob-opensource.loki.loki.storage.s3.secretAccessKey=${S3_SECRET_KEY} \
+		--set mo-ob-opensource.loki.write.persistence.storageClass=${STORAGE_CLASS} \
+		--set mo-ob-opensource.loki.read.persistence.storageClass=${STORAGE_CLASS} \
+		--set mo-ob-opensource.loki.backend.persistence.storageClass=${STORAGE_CLASS} \
+		--set mo-ob-opensource.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName=${STORAGE_CLASS} \
+		--set mo-ruler-stack.grafana.persistence.storageClassName=${STORAGE_CLASS} \
+		--set mo-ruler-stack.grafana.adminUser=${GRAFANA_USER} \
+		--set mo-ruler-stack.grafana.adminPassword=${GRAFANA_PWD} \
+		--set mo-ob-opensource.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage=${PROM_STORAGE_SIZE} \
+		mo-ob-private charts/mo-ob-private
+```
+
+## Detail
+
+This is a helm chart for mo ob in private deployment environment, support basic feature but not alerting:
+
+- logs / metrics data scraping
+- general dashboards are provisioned (in grafana) for monitoring
+
+These component are enabled defalut in chart:
+
+| app                                            | limit              |
+| ------------------------------------------------ | -------------------- |
+| loki-read *1                                   | CPU: 1000 MEM: 3G  |
+| loki-write *1                                  | CPU: 1000 MEM: 1G  |
+| loki-backend *1                                | CPU: 200 MEM: 250M |
+| loki-gateway *1                                | CPU: 1000 MEM: 1G  |
+| prometheus *1                                  | CPU: 1000 MEM: 2G  |
+| prometheus-operator (not set, avg. 50/200M) *1 | CPU: 200 MEM: 400M |
+| promtail (not set, avg. 10/100M) * x           | CPU: 200 MEM: 200M |
+| node-exporter (not set, avg. 10/20M) * x       | CPU: 200 MEM: 100M |
+| grafana (not set, avg. 50/400M) *1             | CPU: 500 MEM: 1G   |

--- a/charts/mo-ob-private/values.yaml
+++ b/charts/mo-ob-private/values.yaml
@@ -1,0 +1,193 @@
+mo-ob-opensource:
+  enabled: true
+
+  promtail:
+    enabled: true
+    resources:
+      limits:
+        cpu: "200m"
+        memory: "200Mi"
+      requests:
+        cpu: "10m"
+        memory: "20Mi"
+  loki:
+    enabled: true
+    tableManager:
+      enabled: true
+      # retention related issue: https://github.com/matrixone-cloud/observability/issues/86
+      retention_deletes_enabled: true
+      retention_period: 720h
+    loki:
+      commonConfig:
+        replication_factor: 1
+      storage:
+        bucketNames:
+          chunks: ""
+        type: s3
+        s3:
+          # s3: null
+          endpoint: 
+          # region: us-west-2
+          secretAccessKey:
+          accessKeyId:
+          s3ForcePathStyle: false
+          insecure: false
+      schemaConfig:
+        configs:
+          - from: "2024-01-01"
+            index:
+              period: 24h
+              prefix: index_
+            object_store: s3
+            schema: v12
+            store: tsdb
+      rulerConfig:
+
+    write:
+      # -- Number of replicas for the write
+      replicas: 1
+      persistence:
+        enableStatefulSetAutoDeletePVC: false
+        size: 10Gi
+        storageClass: 
+      resources:
+        requests:
+          memory: "1Gi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+          cpu: "1000m"
+
+    read:
+      replicas: 1
+      persistence:
+        enableStatefulSetAutoDeletePVC: true
+        size: 10Gi
+        storageClass: 
+      resources:
+        requests:
+          memory: "3Gi"
+          cpu: "250m"
+        limits:
+          memory: "3Gi"
+          cpu: "1000m"
+
+    backend:
+      replicas: 1
+      persistence:
+        enableStatefulSetAutoDeletePVC: true
+        size: 10Gi
+        storageClass: 
+      resources:
+        requests:
+          memory: "250Mi"
+          cpu: "200m"
+        limits:
+          memory: "250Mi"
+          cpu: "200m"
+
+    # Configuration for the gateway
+    gateway:
+      enabled: true
+      replicas: 1
+      resources:
+        requests:
+          memory: "250Mi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+          cpu: "1000m"
+
+  kube-prometheus-stack:
+    enabled: true
+    
+    prometheus-node-exporter: 
+      enabled: true
+      resources: 
+        limits: 
+          cpu:    "200m"
+          memory: "100Mi"
+        requests: 
+          cpu:    "10m"
+          memory: "20Mi"
+    
+    prometheusOperator:
+      resources:
+        limits:
+          cpu: "200m"
+          memory: "400Mi"
+        requests:
+          cpu: "100m"
+          memory: "400Mi"
+    
+    prometheus:
+      prometheusSpec:
+        retention: 21d
+        externalLabels:
+          clusterDetail: mo-ob-private-cluster
+        resources:
+          limits:
+            cpu: 1000m
+            memory: "2Gi"
+          requests:
+            cpu: 1000m
+            memory: "2Gi"
+        # [必要]根据部署的云厂商选择存储配置
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ""
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 40Gi
+    
+    kube-state-metrics:
+      enabled: true
+      prometheus:
+        monitor:
+          enabled: ture
+
+mo-ruler-stack:
+  enabled: true
+  moRuler:
+    enabled: false
+  alertmanager:
+    enabled: false
+
+  grafana:
+    replicas: 1
+    enabled: true
+    resources: 
+      limits: 
+        cpu:    "500m"
+        memory: "1Gi"
+      requests: 
+        cpu:    "200m"
+        memory: "1Gi"
+    
+    persistence: 
+      enabled:          true
+      type:             "statefulset"
+      storageClassName: ""
+      size:             "5Gi"
+    
+    # static passwd
+    adminUser: admin
+    adminPassword: admin
+    admin:
+      existingSecret: ""
+    
+      grafana.ini:
+      auth.generic_oauth:
+        enabled: false
+    
+    service:
+      enabled: true
+      type: ClusterIP
+      port: 80
+      targetPort: 3000
+      labels: {}
+      portName: service
+      # Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+      appProtocol: ""


### PR DESCRIPTION
## What type of PR is this?

* [x] Feature
* [ ] BUG
* [ ] Alerts
* [ ] Improvement
* [ ] Documentation
* [ ] Test and CI

## Which issue(s) this PR related:

issue # https://github.com/matrixorigin/MO-Cloud/issues/2266

## What this PR does / why we need it:

This is a helm chart for mo ob in private deployment environment, support basic feature but not alerting:

- logs / metrics data scraping
- general dashboards are provisioned (in grafana) for monitoring

These component are enabled defalut in chart:

| app                                            | limit              |
| ------------------------------------------------ | -------------------- |
| loki-read *1                                   | CPU: 1000 MEM: 3G  |
| loki-write *1                                  | CPU: 1000 MEM: 1G  |
| loki-backend *1                                | CPU: 200 MEM: 250M |
| loki-gateway *1                                | CPU: 1000 MEM: 1G  |
| prometheus *1                                  | CPU: 1000 MEM: 2G  |
| prometheus-operator (not set, avg. 50/200M) *1 | CPU: 200 MEM: 400M |
| promtail (not set, avg. 10/100M) * x           | CPU: 200 MEM: 200M |
| node-exporter (not set, avg. 10/20M) * x       | CPU: 200 MEM: 100M |
| grafana (not set, avg. 50/400M) *1             | CPU: 500 MEM: 1G   |