### PR TITLE
fix(): private chart  template 添加占位文件用于私有化打包

### DIFF
--- a/charts/mo-ob-private/Chart.yaml
+++ b/charts/mo-ob-private/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ob-private
 description: mo-ob-private's Helm chart for Kubernetes
 type: application
-version: 1.0.0-alpha
+version: 1.0.0-alpha.1
 appVersion: 0.9.0
 dependencies:
 - condition: mo-ob-opensource.enabled

--- a/charts/mo-ob-private/templates/empty.yaml
+++ b/charts/mo-ob-private/templates/empty.yaml
@@ -1,0 +1,2 @@
+# DO NOT EDIT ON THIS
+# this file is just a placeholder


### PR DESCRIPTION
## What type of PR is this?

* [ ] Feature
* [x] BUG
* [ ] Alerts
* [ ] Improvement
* [ ] Documentation
* [ ] Test and CI

## Which issue(s) this PR related:

issue #

## What this PR does / why we need it:

私有化打包需要 chart 内存在 template 文件夹，添加一个占位文件以达到目的

<img width="944" alt="image" src="https://github.com/matrixone-cloud/observability-charts/assets/69068661/20152541-a473-44e8-ae61-3761bbde87d9">

