### PR TITLE
chore: support policies & dashboard switch with default false enabled

### DIFF
--- a/charts/mo-ob-opensource/Chart.yaml
+++ b/charts/mo-ob-opensource/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ob-opensource
 description: mo-ob-opensource's Helm chart for Kubernetes
 type: application
-version: 1.0.0-alpha.16
+version: 1.0.1
 appVersion: 0.9.0
 dependencies:
 - condition: kube-prometheus-stack.enabled

--- a/charts/mo-ob-opensource/templates/log-alert-rules.yaml
+++ b/charts/mo-ob-opensource/templates/log-alert-rules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertrules.enabled }}
 ## cooperate with {folder_to_char}/alert-rules/log-alert-rules/*.yaml
 {{- $files := .Files.Glob "alert-rules/log-alert-rules/*.yaml" }}
 {{- if $files }}
@@ -18,3 +19,4 @@ items:
    {{ printf "%s.yaml" $alertFileName }}: {{ $.Files.Get $path | toYaml | indent 2}}
 {{- end }}
 {{- end }}
+{{- end }} # end if enabled

--- a/charts/mo-ob-opensource/templates/mo-alerting-rules.yaml
+++ b/charts/mo-ob-opensource/templates/mo-alerting-rules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertrules.enabled }}
 apiVersion: v1
 kind: List
 metadata:
@@ -22,4 +23,5 @@ items:
         heritage: Helm
     spec:
     {{ $root.Files.Get $path | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -1,6 +1,13 @@
 alerting:
   namespace: "mo-ob"
 
+# swith for generate alertrules which defined in `rules` folder
+# - cooperate with template templates/mo-alerting-rules.yaml
+# swith for generate alertrules which defined in `alert-rules/log-alert-rules` folder
+# - cooperate with template templates/log-alert-rules.yaml
+alertrules:
+  enabled: false
+
 promtail:
   enabled: true
   serviceMonitor:

--- a/charts/mo-ruler-stack/Chart.yaml
+++ b/charts/mo-ruler-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ruler-stack
 description: mo-ruler's Helm chart for Kubernetes
 type: application
-version: 1.0.0-alpha.13
+version: 1.0.1
 appVersion: 0.9.0
 dependencies:
 - condition: alertmanager.enabled

--- a/charts/mo-ruler-stack/templates/grafana/dashboards-configmap.yaml
+++ b/charts/mo-ruler-stack/templates/grafana/dashboards-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafana.enabled }}
+{{- if (and .Values.grafana.enabled .Values.dashboards.enabled ) }}
 {{- $files := .Files.Glob "grafana/dashboards/*.json" }}
 {{- if $files }}
 apiVersion: v1

--- a/charts/mo-ruler-stack/templates/rules-config.yaml
+++ b/charts/mo-ruler-stack/templates/rules-config.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.moRuler.enabled }} 
+{{ if (and .Values.moRuler.enabled .Values.alertrules.enabled) }}
 
 apiVersion: v1
 data:

--- a/charts/mo-ruler-stack/values.yaml
+++ b/charts/mo-ruler-stack/values.yaml
@@ -17,6 +17,16 @@ secretSeed:
   ## param for templates/grafana/grafana-admin-secret.yaml
   grafana: YXNkZl9wYXNzd29y
 
+# swith for generate dashboards which defined in `grafana` folder
+# cooperate with template templates/grafana/dashboards-configmap.yaml
+dashboards:
+  enabled: false
+
+# swith for generate dashboards which defined in `rules` folder
+# cooperate with template templates/rules-config.yaml
+alertrules:
+  enabled: false
+
 moRuler:
   replicaCount: 1
   enabled: false


### PR DESCRIPTION
## What type of PR is this?

* [ ] Feature
* [ ] BUG
* [x] Alerts
* [x] Improvement
* [ ] Documentation
* [x] Test and CI

## Which issue(s) this PR related:

issue #  https://github.com/matrixorigin/MO-Cloud/issues/2339

## What this PR does / why we need it:
changes:
1. default disable `mo-ruler-stack` and `mo-ob-opensource` deploy alert rules
2. default disable `mo-ruler-stack` deploy dashboards.
3. change chart as 1.0.1 