### PR TITLE
chore(): support enable/close webhook-adapter and update ruler-stack to 1.0.2

### DIFF
--- a/charts/mo-ob-private/values.yaml
+++ b/charts/mo-ob-private/values.yaml
@@ -187,6 +187,14 @@ mo-ruler-stack:
   enabled: true
   moRuler:
     enabled: false
+  
+  # webhook adapter for alertmanger to send alert to wecom
+  alertmanagerWebhookAdapter:
+    enabled: false
+    image:
+      repository: ez4bruce3280/alertmanager-webhook-adapter
+      tag: v1.1.7
+  
   alertmanager:
     enabled: false
 

--- a/charts/mo-ob-private/values.yaml
+++ b/charts/mo-ob-private/values.yaml
@@ -187,7 +187,6 @@ mo-ruler-stack:
   enabled: true
   moRuler:
     enabled: false
-
   alertmanager:
     enabled: false
 

--- a/charts/mo-ob-private/values.yaml
+++ b/charts/mo-ob-private/values.yaml
@@ -187,14 +187,7 @@ mo-ruler-stack:
   enabled: true
   moRuler:
     enabled: false
-  
-  # webhook adapter for alertmanger to send alert to wecom
-  alertmanagerWebhookAdapter:
-    enabled: false
-    image:
-      repository: ez4bruce3280/alertmanager-webhook-adapter
-      tag: v1.1.7
-  
+
   alertmanager:
     enabled: false
 

--- a/charts/mo-ruler-stack/Chart.yaml
+++ b/charts/mo-ruler-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ruler-stack
 description: mo-ruler's Helm chart for Kubernetes
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.9.0
 dependencies:
 - condition: alertmanager.enabled

--- a/charts/mo-ruler-stack/templates/webhook-adapter-deployment.yaml
+++ b/charts/mo-ruler-stack/templates/webhook-adapter-deployment.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.alertmanagerWebhookAdapter.enabled }} 
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,7 +17,7 @@ spec:
     spec:
       containers:
       - name: webhook
-        image: ez4bruce3280/alertmanager-webhook-adapter:v1.1.7
+        image: {{ .Values.alertmanagerWebhookAdapter.image.repository }}:{{ .Values.alertmanagerWebhookAdapter.image.tag }}
         command:
         - /alertmanager-webhook-adapter
         - --listen-address=:8090
@@ -41,3 +43,5 @@ spec:
         configMap:
           name: alert-template-config-map
       restartPolicy: Always
+
+{{ end }}

--- a/charts/mo-ruler-stack/templates/webhook-adapter-service.yaml
+++ b/charts/mo-ruler-stack/templates/webhook-adapter-service.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.alertmanagerWebhookAdapter.enabled }} 
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,3 +12,5 @@ spec:
   selector:
     app: alertmanager-webhook-adapter
   sessionAffinity: None
+
+{{ end }}

--- a/charts/mo-ruler-stack/values.yaml
+++ b/charts/mo-ruler-stack/values.yaml
@@ -127,6 +127,13 @@ moRuler:
         pageTitle: MO-Ruler Server
         appName: MO-Ruler
 
+# webhook adapter for alertmanger to send alert to wecom
+alertmanagerWebhookAdapter:
+  enabled: true
+  image:
+    repository: ez4bruce3280/alertmanager-webhook-adapter
+    tag: v1.1.7
+
 ## alertmanager sub-chart configurable values
 ## Please see https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager
 ##


### PR DESCRIPTION
## What type of PR is this?

* [ ] Feature
* [x] BUG
* [ ] Alerts
* [ ] Improvement
* [ ] Documentation
* [ ] Test and CI

## Which issue(s) this PR related:

issue #

## What this PR does / why we need it:

由于私有化环境打包时渲染 webhook-adapter 的模板出错导致无法打包，目前私有化场景也没有使用 webhook-adapter 的需求，因此为 alertmanager-webhook-adapter 添加开关
