### PR TITLE
Upload Opensource 1.0.2 alpha

### DIFF
--- a/charts/mo-ob-opensource/Chart.yaml
+++ b/charts/mo-ob-opensource/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ob-opensource
 description: mo-ob-opensource's Helm chart for Kubernetes
 type: application
-version: 1.0.2
+version: 1.0.2.alpha
 appVersion: 0.9.0
 dependencies:
 - condition: kube-prometheus-stack.enabled
@@ -17,4 +17,3 @@ dependencies:
   name: promtail
   repository: https://grafana.github.io/helm-charts
   version: 6.15.1
-

--- a/charts/mo-ob-opensource/Chart.yaml
+++ b/charts/mo-ob-opensource/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ob-opensource
 description: mo-ob-opensource's Helm chart for Kubernetes
 type: application
-version: 1.0.2.alpha
+version: 1.0.2-alpha
 appVersion: 0.9.0
 dependencies:
 - condition: kube-prometheus-stack.enabled

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -145,21 +145,22 @@ loki:
           directory: /rules
       alertmanager_url: http://mo-ob-alertmanager.mo-ob:9093
     # -- Additional query scheduler config
-    storage_config:
-      boltdb_shipper: 
-        active_index_directory: /var/loki/data/loki/boltdb-shipper-active
-        cache_location: /var/loki/data/loki/boltdb-shipper-cache
-        cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
-        shared_store: s3
-      tsdb_shipper:
-        active_index_directory: /var/loki/data/loki/tsdb-index
-        cache_location: /var/loki/data/loki/tsdb-cache
-        shared_store: s3
-      # alibabacloud:
-      #   bucket: <bucket>
-      #   endpoint: <endpoint>
-      #   access_key_id: <access_key_id>
-      #   secret_access_key: <secret_access_key>
+    ### use default config, old config not work in loki 3.0.0
+    #storage_config:
+    #  boltdb_shipper:
+    #    active_index_directory: /var/loki/data/loki/boltdb-shipper-active
+    #    cache_location: /var/loki/data/loki/boltdb-shipper-cache
+    #    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    #    shared_store: s3
+    #  tsdb_shipper:
+    #    active_index_directory: /var/loki/data/loki/tsdb-index
+    #    cache_location: /var/loki/data/loki/tsdb-cache
+    #    shared_store: s3
+    #  # alibabacloud:
+    #  #   bucket: <bucket>
+    #  #   endpoint: <endpoint>
+    #  #   access_key_id: <access_key_id>
+    #  #   secret_access_key: <secret_access_key>
   sidecar:
     rules:
       label: loki_rule

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -106,7 +106,7 @@ loki:
       http_server_write_timeout: 300s
     # -- Limits config
     limits_config:
-      enforce_metric_name: false
+      #enforce_metric_name: false ### removed in loki 3.0.0
       reject_old_samples: true
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -135,6 +135,13 @@ loki:
     # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
     schemaConfig: 
       configs:
+      - from: 2024-04-01
+        object_store: s3
+        store: tsdb
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
     # -- Check https://grafana.com/docs/loki/latest/configuration/#ruler for more info on configuring ruler
     rulerConfig: 
       evaluation_interval: 1m

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -111,6 +111,7 @@ loki:
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
       split_queries_by_interval: 15m
+      max_label_names_per_series: 30
     query_scheduler:
       max_outstanding_requests_per_tenant: 10000
     frontend:


### PR DESCRIPTION
## What type of PR is this?

* [x] Feature
* [ ] BUG
* [ ] Alerts
* [ ] Improvement
* [ ] Documentation
* [ ] Test and CI

## Which issue(s) this PR related:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3134

## What this PR does / why we need it:
changes:
1. 去掉values.yaml 不兼容 loki 3.0.0 的配置项, `limits_config:enforce_metric_name`
2. reset `limits_config: max_label_names_per_series = 30`
3. 去掉 storage_config 不兼容的配置： tsdb_shiper 和 boltdb_shipper 
4. 补充 svc/loki-gateway 创建


link
- loki 3.0 default 更新 https://grafana.com/docs/loki/latest/setup/upgrade/#changes-to-default-configuration-values-in-30
- schema v13, https://grafana.com/docs/loki/latest/operations/storage/schema/

error info
```
failed parsing config: /etc/loki/config/config.yaml: yaml: unmarshal errors:
  line 27: field enforce_metric_name not found in type validation.plain
  line 84: field shared_store not found in type boltdb.IndexCfg
  line 101: field shared_store not found in type indexshipper.Config. Use `-config.expand-env=true` flag if you want to expand environment variables in your config file
```