### PR TITLE
feat: handle kube-state-metrics.serviceAccount creation

### DIFF
--- a/charts/mo-ob-opensource/Chart.yaml
+++ b/charts/mo-ob-opensource/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mo-ob-opensource
 description: mo-ob-opensource's Helm chart for Kubernetes
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: 0.9.0
 dependencies:
 - condition: kube-prometheus-stack.enabled

--- a/charts/mo-ob-opensource/templates/kube-state-metrics-sa.yaml
+++ b/charts/mo-ob-opensource/templates/kube-state-metrics-sa.yaml
@@ -1,0 +1,9 @@
+{{- with .Values.kube-prometheus-stack -}}
+{{- if .kube-state-metrics.serviceAccount.create - }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .kube-state-metrics.serviceAccount.name }}
+  namespace: {{ .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/charts/mo-ob-opensource/templates/kube-state-metrics-sa.yaml
+++ b/charts/mo-ob-opensource/templates/kube-state-metrics-sa.yaml
@@ -1,9 +1,7 @@
-{{- with .Values.kube-prometheus-stack -}}
-{{- if .kube-state-metrics.serviceAccount.create - }}
+{{- if not .Values.serviceAccount.kubeStateMetrics.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .kube-state-metrics.serviceAccount.name }}
+  name: {{ default "mo-ob-opensource-kube-state-metrics" .Values.serviceAccount.kubeStateMetrics.name }}
   namespace: {{ .Release.Name }}
-{{- end -}}
 {{- end -}}

--- a/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
+++ b/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
@@ -1,7 +1,0 @@
-{{- if not .Values.serviceAccount.prometheusNodeExporter.create -}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ default "mo-ob-opensource-prometheus-node-exporter" .Values.serviceAccount.prometheusNodeExporter.name }}
-  namespace: {{ $.Release.Name }}
-{{- end -}}

--- a/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
+++ b/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
@@ -1,9 +1,9 @@
 {{- with .Values.kube-prometheus-stack -}}
-{{- if and .prometheus-node-exporter.rbac.create not .Values.serviceAccount.create -}}
+{{- if and .prometheus-node-exporter.rbac.create not .prometheus-node-exporter.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .prometheus-node-exporter.serviceAccountName }}
-  namespace: {{ .Release.Name }}
+  name: {{ .prometheus-node-exporter.serviceAccount.name }}
+  namespace: {{ $.Release.Name }}
 {{- end -}}
 {{- end -}}

--- a/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
+++ b/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
@@ -1,0 +1,9 @@
+{{- with .Values.kube-prometheus-stack -}}
+{{- if and .prometheus-node-exporter.rbac.create not .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .prometheus-node-exporter.serviceAccountName }}
+  namespace: {{ .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
+++ b/charts/mo-ob-opensource/templates/prometheus-node-exporter-sa.yaml
@@ -1,9 +1,7 @@
-{{- with .Values.kube-prometheus-stack -}}
-{{- if and .prometheus-node-exporter.rbac.create not .prometheus-node-exporter.serviceAccount.create -}}
+{{- if not .Values.serviceAccount.prometheusNodeExporter.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .prometheus-node-exporter.serviceAccount.name }}
+  name: {{ default "mo-ob-opensource-prometheus-node-exporter" .Values.serviceAccount.prometheusNodeExporter.name }}
   namespace: {{ $.Release.Name }}
-{{- end -}}
 {{- end -}}

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -365,6 +365,11 @@ kube-prometheus-stack:
         enabled: false
     tolerations:
     - operator: Exists
+    rbac:
+      create: true
+    serviceAccount:
+      create: true
+      name:
   kubeStateMetrics:
     enabled: true
   kube-state-metrics:
@@ -372,6 +377,9 @@ kube-prometheus-stack:
     prometheus:
       monitor:
         enabled: false
+    serviceAccount:
+      create: true
+      name:
 
   prometheusOperator:
     enabled: true

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -8,6 +8,28 @@ alerting:
 alertrules:
   enabled: false
 
+## handle chart kube-prometheus-stack's sub-chart serviceAccount create with imagePullSecrets case
+## cc https://github.com/matrixorigin/MO-Cloud/issues/4464
+## ---- IMPORTANT ----
+## this section MUST eq the 'kube-prometheus-stack' section, like:
+# kube-prometheus-stack:
+#   prometheus-node-exporter:
+#     serviceAccount:
+#       create: true
+#       name:
+#   kube-state-metrics:
+#     enabled: true
+#     serviceAccount:
+#       create: true
+#       name:
+serviceAccount:
+  prometheusNodeExporter:
+    create: true
+    name: "mo-ob-opensource-prometheus-node-exporter"
+  kubeStateMetrics:
+    create: true
+    name: "mo-ob-opensource-kube-state-metrics"
+
 defaultDatasource:
   # from matrixorigin/ops
   # cooperate with template templates/loki-datasource.yaml
@@ -15,7 +37,6 @@ defaultDatasource:
 
 # alloy for k8s events
 alloy:
-  
   image:
     registry: "docker.io"
     repository: grafana/alloy

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -21,6 +21,7 @@ alertrules:
 serviceAccount:
   kubeStateMetrics:
     handle: false
+    ## if handle = ture, pls sync this value with kube-state-metrics.serviceAccount.name
     name: "mo-ob-opensource-kube-state-metrics"
 
 defaultDatasource:

--- a/charts/mo-ob-opensource/values.yaml
+++ b/charts/mo-ob-opensource/values.yaml
@@ -13,21 +13,14 @@ alertrules:
 ## ---- IMPORTANT ----
 ## this section MUST eq the 'kube-prometheus-stack' section, like:
 # kube-prometheus-stack:
-#   prometheus-node-exporter:
-#     serviceAccount:
-#       create: true
-#       name:
 #   kube-state-metrics:
 #     enabled: true
 #     serviceAccount:
 #       create: true
 #       name:
 serviceAccount:
-  prometheusNodeExporter:
-    create: true
-    name: "mo-ob-opensource-prometheus-node-exporter"
   kubeStateMetrics:
-    create: true
+    handle: false
     name: "mo-ob-opensource-kube-state-metrics"
 
 defaultDatasource:
@@ -386,11 +379,6 @@ kube-prometheus-stack:
         enabled: false
     tolerations:
     - operator: Exists
-    rbac:
-      create: true
-    serviceAccount:
-      create: true
-      name:
   kubeStateMetrics:
     enabled: true
   kube-state-metrics:


### PR DESCRIPTION
## What type of PR is this?

* [ ] Feature
* [x] BUG
* [ ] Alerts
* [x] Improvement
* [ ] Documentation
* [ ] Test and CI

## Which issue(s) this PR related:

issue # https://github.com/matrixorigin/MO-Cloud/issues/4464

## What this PR does / why we need it:
为 mo-ob-opensource 添加配置，管理 `kube-state-metrics.serviceAccount` 创建

default case:
- mo-ob-opensource chart NOT create serviceAccount for kube-state-metrics
- kube-state-metrics sub-chart create its own serviceAccount with specified imagePullSecrets args.

handle case:
- mo-ob-opensource chart CREATE serviceAccount for kube-state-metrics without `imagePullSecrets`
- kube-state-metrics sub-chart NOT create its own serviceAccount
- example of user-values:
```diff
serviceAccount:
  kubeStateMetrics:
-    handle: false
+    handle: true
+    name: "mo-ob-opensource-kube-state-metrics"

kube-prometheus-stack:
  kube-state-metrics:
+    serviceAccount:
+      create: false
+      name: "mo-ob-opensource-kube-state-metrics"
    ...
```
